### PR TITLE
Fix AWS config/secret class

### DIFF
--- a/pygluu/containerlib/config/aws_config.py
+++ b/pygluu/containerlib/config/aws_config.py
@@ -136,6 +136,9 @@ class AwsConfig(BaseConfig):
         # SecretString is a `dict` data type
         data: dict[str, _t.Any] = _load_value(resp["SecretString"])
         return data
+    
+    def all(self) -> dict:
+        return self.get_all()
 
     def get(self, key: str, default: _t.Any = "") -> _t.Any:
         """Get value based on given key.

--- a/pygluu/containerlib/secret/aws_secret.py
+++ b/pygluu/containerlib/secret/aws_secret.py
@@ -137,6 +137,9 @@ class AwsSecret(BaseSecret):
         # SecretBinary is a `dict` data type
         data: dict[str, _t.Any] = _load_value(resp["SecretBinary"])
         return data
+    
+    def all(self) -> dict:
+        return self.get_all()
 
     def get(self, key: str, default: _t.Any = "") -> _t.Any:
         """Get value based on given key.


### PR DESCRIPTION
Fixing Issue #37 
Added `all()` method that was required by base_secret/config class