### PR TITLE
test: add testcases for get_all,set_all, and all methods

### DIFF
--- a/pygluu/containerlib/config/consul_config.py
+++ b/pygluu/containerlib/config/consul_config.py
@@ -145,7 +145,7 @@ class ConsulConfig(BaseConfig):
         """
         return self.client.kv.put(self._merge_path(key), safe_value(value))
 
-    def all(self) -> dict[str, Any]:
+    def all(self) -> dict[str, Any]:  # pragma: no cover
         return self.get_all()
 
     def get_all(self) -> dict[str, Any]:

--- a/pygluu/containerlib/config/kubernetes_config.py
+++ b/pygluu/containerlib/config/kubernetes_config.py
@@ -115,7 +115,7 @@ class KubernetesConfig(BaseConfig):
         )
         return bool(ret)
 
-    def all(self) -> dict[str, Any]:
+    def all(self) -> dict[str, Any]:  # pragma: no cover
         return self.get_all()
 
     def get_all(self) -> dict[str, Any]:

--- a/pygluu/containerlib/secret/kubernetes_secret.py
+++ b/pygluu/containerlib/secret/kubernetes_secret.py
@@ -116,7 +116,7 @@ class KubernetesSecret(BaseSecret):
         )
         return bool(ret)
 
-    def all(self) -> dict:
+    def all(self) -> dict:  # pragma: no cover
         return self.get_all()
 
     def get_all(self) -> dict:

--- a/pygluu/containerlib/secret/vault_secret.py
+++ b/pygluu/containerlib/secret/vault_secret.py
@@ -160,7 +160,7 @@ class VaultSecret(BaseSecret):
         )
         return response.status_code == 204
 
-    def all(self) -> dict:
+    def all(self) -> dict:  # pragma: no cover
         return self.get_all()
 
     def get_all(self) -> dict:


### PR DESCRIPTION
Overview:

- add testcase for `set_all` and `get_all` methods
- exclude deprecated `all` method from coverage