### PR TITLE
fix: handle AWS secrets insufficient size

### DIFF
--- a/pygluu/containerlib/secret/aws_secret.py
+++ b/pygluu/containerlib/secret/aws_secret.py
@@ -193,10 +193,14 @@ class AwsSecret(BaseSecret):
         Returns:
             A boolean indicating if the operation was successful.
         """
-        return self._update_secret_multipart(_dump_value(
+        # fetch existing data (if any) as we will merge them;
+        # note that existing value will be overwritten
+        payload = self.get_all()
+
+        for k, v in data.items():
             # ensure key-value that has bytes is converted to text
-            {k: safe_value(v) for k, v in data.items()}
-        ))
+            payload[k] = safe_value(v)
+        return self._update_secret_multipart(_dump_value(payload))
 
     @cached_property
     def replica_regions(self) -> list[dict[str, _t.Any]]:


### PR DESCRIPTION
Overview:

- secrets created by AWS wrapper will be split into multiparts if size is > 64K (initial work by @venc-gy)
- compression is removed as it's no longer relevant in multiparts
- add backward-compat for legacy data

Closes #45 